### PR TITLE
Add Docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+ENTRYPOINT ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -31,3 +31,28 @@ Delete an entry by id:
 ```bash
 python app.py delete 1
 ```
+
+## Docker
+
+If you don't have Python installed, you can run the application in a container.
+
+Build the image:
+
+```bash
+docker build -t crudex .
+```
+
+Run commands using the container (data will not persist between runs):
+
+```bash
+docker run --rm crudex add "John Doe" "john@example.com"
+docker run --rm crudex list
+```
+
+To preserve the database, mount a volume:
+
+```bash
+docker volume create crudex_data
+docker run --rm -v crudex_data:/app crudex add "Jane Doe" "jane@example.com"
+docker run --rm -v crudex_data:/app crudex list
+```


### PR DESCRIPTION
## Summary
- add Dockerfile for running Python app inside container
- ignore unnecessary files for Docker context
- document how to build and run with Docker

## Testing
- `python3 -m py_compile app.py`
- ❌ `docker build -t crudex .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68445ab95e14832cb81666cd12294bdb