### PR TITLE
Fix quoting in makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ list:
 	$(DC) run --rm crudex list
 
 add:
-	$(DC) run --rm crudex add $(NAME) $(EMAIL)
+	$(DC) run --rm crudex add "$(NAME)" "$(EMAIL)"
 
 update:
-	$(DC) run --rm crudex update $(ID) $(NAME) $(EMAIL)
+	$(DC) run --rm crudex update $(ID) "$(NAME)" "$(EMAIL)"
 
 delete:
 	$(DC) run --rm crudex delete $(ID)


### PR DESCRIPTION
## Summary
- ensure `make add` and `make update` handle names with spaces

## Testing
- `make add NAME="John Doe" EMAIL="john@example.com"` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684465ef22a0832c9d35adc2269a8968