### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ update:
 	$(PYTHON) app.py update $(ID) "$(NAME)" "$(EMAIL)"
 
 delete:
-        $(PYTHON) app.py delete $(ID)
+	$(PYTHON) app.py delete $(ID)
 
 console:
-        $(PYTHON) console.py
+	$(PYTHON) console.py
 


### PR DESCRIPTION
## Summary
- correct indentation for `delete` and `console` targets

## Testing
- `python3 -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684480a3d960832c862aeaa8f20746af