### PR TITLE
Default Makefile goal to console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 PYTHON := python3
 
+# Run the interactive console by default
+.DEFAULT_GOAL := console
+
 .PHONY: install list add get update delete console
 
 install:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ It is designed to be lightweight, dependency-free, and easy to understand — id
 
 ## Usage
 
-You can run the application via the provided `Makefile`.
+You can run the application via the provided `Makefile`. Simply running `make`
+will launch the interactive console.
 
 ### Using the Makefile
 


### PR DESCRIPTION
## Summary
- make the interactive console the default Makefile goal
- document in README that running `make` launches the console

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448248d3d8832ca40efdb9c948f1b7