### PR TITLE
Clarify testing install step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ PYTHON := python3
 # Run the interactive console by default
 .DEFAULT_GOAL := console
 
-.PHONY: install list add get update delete console
 
-install:
+.PHONY: install-dependencies list add get update delete console
+
+install-dependencies:
 	$(PYTHON) -m pip install -r requirements.txt
 
 list:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make console
 
 ## Running tests
 
-Install the testing dependency:
+Install the testing dependency (also available via `make install-dependencies`):
 
 ```bash
 python3 -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- clarify that `make install` installs test dependencies
- rename `make install` to `make install-dependencies`

## Testing
- `make install-dependencies`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844830c8b4c832ca8c7f011780fa30b