### PR TITLE
Add console tests and purge command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 PYTHON := python3
+DB_NAME ?= crudex.db
 
 # Run the interactive console by default
 .DEFAULT_GOAL := console
 
 
-.PHONY: install-dependencies list add get update delete console
+.PHONY: install-dependencies list add get update delete console purge
 
 install-dependencies:
 	$(PYTHON) -m pip install -r requirements.txt
@@ -27,3 +28,5 @@ delete:
 console:
 	$(PYTHON) console.py
 
+purge:
+	rm -f $(DB_NAME)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is designed to be lightweight, dependency-free, and easy to understand — id
 You can run the application via the provided `Makefile`. Simply running `make`
 will launch the interactive console.
 
-### Using the Makefile
+### Comandos de consola
 
 ```bash
 make list
@@ -25,6 +25,14 @@ make get ID=1
 make update ID=1 NAME="Sandra Alonso" EMAIL="sandra@example.com"
 make delete ID=1
 make console
+make purge
+```
+
+### Comandos manuales
+
+```bash
+python app.py list
+python app.py add "Name" "email@example.com"
 ```
 
 ## Running tests

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+
+import console
+from app import Database
+
+
+def test_interactive_menu_add_entry(monkeypatch, tmp_path):
+    db_path = tmp_path / 'console.db'
+    monkeypatch.setenv('DB_NAME', str(db_path))
+    importlib.reload(console)
+
+    inputs = iter([
+        '1',
+        'Alice',
+        'alice@example.com',
+        '',
+        '6'
+    ])
+    monkeypatch.setattr('builtins.input', lambda *args: next(inputs))
+    monkeypatch.setattr('os.system', lambda *args, **kwargs: None)
+
+    console.interactive_menu()
+
+    db = Database()
+    entries = db.list_entries()
+    assert len(entries) == 1
+    assert entries[0].name == 'Alice'
+    assert entries[0].email == 'alice@example.com'


### PR DESCRIPTION
## Summary
- add new `purge` rule in the Makefile
- create `test_console.py` for the interactive menu
- document the new command and split important console commands from manual ones in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448499a7a4832cb13279ec968818ac